### PR TITLE
Drop tempItems only if no soulgem is in inventory

### DIFF
--- a/src/main/java/dev/anhcraft/keepmylife/KeepMyLife.java
+++ b/src/main/java/dev/anhcraft/keepmylife/KeepMyLife.java
@@ -260,7 +260,9 @@ public final class KeepMyLife extends JavaPlugin implements KMLApi, Listener {
                 } else if(hasSoulGem) keptItems.add(item);
                 else tempItems.add(item); // do not remove item directly, we do not know if the inventory has a soul gem
             }
-            dropItems.addAll(tempItems);
+            if (!hasSoulGem) {
+                dropItems.addAll(tempItems);
+            }
         } else {
             dropItems.addAll(ArrayUtil.toList(p.getInventory().getContents()));
         }


### PR DESCRIPTION
With the latest stable spigot server (1.14.4) I had the issue that some items in the inventory dropped even with a soulgem inside it. This seem to be the items added in tempItems.